### PR TITLE
feat: zsh, hypr, and install improvements

### DIFF
--- a/.zprofile
+++ b/.zprofile
@@ -1,0 +1,10 @@
+
+if [ -z "$DISPLAY" ] && [ "$(tty)" = "/dev/tty1" ]; then
+  if $(gum confirm "Start Hyprland?"); then
+    gum log --level info "Starting Hyprland..."
+    start-hyprland
+  fi
+fi
+# if [ -z "$DISPLAY" ] && [ "$(tty)" = "/dev/tty1" ]; then
+#     exec start-hyprland
+# fi


### PR DESCRIPTION
## Summary

- Add `.zprofile` with interactive Hyprland autostart prompt using `gum`
- Add `hypr-logout` script and split autologin into separate getty/sddm modes
- Fix `tmux-sessionizer` fzf search directories
- Add new packages and install script improvements

## Changes

- `.zprofile` — prompts user on tty1 whether to start Hyprland (via `gum confirm`)
- `.local/bin/hypr-logout` — new logout helper script
- `install.d/hypr/autologin-getty.sh` / `autologin-sddm.sh` — split autologin modes
- `install.d/hypr/desktop.sh` — new desktop install script
- `install.d/envs.sh` — expanded environment setup
- `install.d/core/packages.txt`, `install.d/hypr/packages.txt` — new packages
- `.local/bin/tmux-sessionizer` — corrected fzf search paths

## Test plan

- [ ] Boot to tty1 and confirm Hyprland prompt appears
- [ ] Test `hypr-logout` script
- [ ] Verify autologin works for both getty and sddm modes
- [ ] Run install scripts on a fresh environment