### PR TITLE
feat(hypr): add rofi keybind viewer and workspace cycling binds

### DIFF
--- a/.config/hypr/modules/envs.lua
+++ b/.config/hypr/modules/envs.lua
@@ -19,5 +19,6 @@ hl.config({
 		"CLUTTER_BACKEND,wayland",
 		"GDK_BACKEND,wayland,x11",
 		"MOZ_ENABLE_WAYLAND,1",
+    "PATH,~/.local/bin:$PATH"
 	},
 })

--- a/.config/hypr/modules/keybinds.lua
+++ b/.config/hypr/modules/keybinds.lua
@@ -42,8 +42,8 @@ hl.bind(
 hl.bind(MAIN_MOD .. " + N", hl.dsp.exec_cmd(NOTES), { description = "󰠮 Launch Notes (" .. NOTES .. ")" })
 hl.bind(
   MAIN_MOD .. " + K",
-  hl.dsp.exec_cmd("~/.local/share/omarchy/bin/omarchy-menu-keybindings"),
-  { description = "󰌌 Show/Search Keybinds" }
+  hl.dsp.exec_cmd("~/.local/bin/hypr-show-keybinds"),
+  { description = "󰌌 Show/Search Hyprland Keybinds" }
 )
 
 ----------------------------
@@ -65,7 +65,22 @@ end
 hl.bind(MAIN_MOD .. " + mouse:272", hl.dsp.window.drag(), { description = "🖱️ Move window." })
 hl.bind(MAIN_MOD .. " + SHIFT + mouse:272", hl.dsp.window.resize(), { description = "🖱️ Resize window." })
 
------------------------------
+hl.bind(MAIN_MOD .. " + bracketright", function()
+    hl.dsp.window.cycle_next({ "e+1", 'scrolling'})
+end, { description = "Cycle/move to the next non-empty window."})
+
+hl.bind(MAIN_MOD .. " + bracketright", function()
+end, { description = "Cycle/move to the previous non-empty window."})
+
+hl.bind(MAIN_MOD .. " + SHIFT + bracketright", function()
+    hl.dispatch(hl.dsp.focus({ workspace = "e+1" }))
+end, { description = "Cycle/move to the next non-empty workspace."})
+
+hl.bind(MAIN_MOD .. "+ SHIFT + bracketleft", function()
+    hl.dispatch(hl.dsp.focus({ workspace = "e-1" }))
+end, { description = "Cycle/move to the previous non-empty workspace."})
+
+-----------------------
 ---- MEDIA/ETC. KEYBINDS ----
 -----------------------------
 -- Laptop multimedia keys for volume and LCD brightness
@@ -121,3 +136,4 @@ hl.bind(
   hl.dsp.exec_cmd("playerctl previous"),
   { description = "󰒮 Previous Media/Audio Track", locked = true }
 )
+

--- a/.config/hypr/modules/layouts.lua
+++ b/.config/hypr/modules/layouts.lua
@@ -24,7 +24,7 @@ hl.config({
   },
 })
 
-hl.gesture({ fingers = 4, direction = "horizontal", scale = 1.5, action = "scroll_move" })
-hl.gesture({ fingers = 3, direction = "horizontal", scale = 1.5, action = "workspace" })
+hl.gesture({ fingers = 3, direction = "horizontal", scale = 1.5, action = "scroll_move" })
+hl.gesture({ fingers = 4, direction = "horizontal", scale = 1.5, action = "workspace" })
 hl.gesture({ fingers = 3, direction = "down", scale = 1.5, mods = "ALT", action = "close" })
 hl.gesture({ fingers = 4, direction = "pinchout", scale = 1.5, action = "fullscreen" })

--- a/.config/rofi/simple.rasi
+++ b/.config/rofi/simple.rasi
@@ -1,0 +1,173 @@
+/**
+ *
+ * Author : Aditya Shakya (adi1090x)
+ * Github : @adi1090x
+ * 
+ * Rofi Theme File
+ * Rofi Version: 1.7.3
+ **/
+
+/*****----- Configuration -----*****/
+configuration {
+	modi:                       "drun";
+    show-icons:                 true;
+    display-drun:               "";
+	drun-display-format:        "{name}";
+}
+
+/*****----- Global Properties -----*****/
+@import                          "~/.config/dtd/current/rofi.rasi"
+@import                          "~/.config/rofi/fonts.rasi"
+
+/*****----- Main Window -----*****/
+window {
+    transparency:                "real";
+    location:                    center;
+    anchor:                      center;
+    fullscreen:                  false;
+    width:                       60%;
+    height:                      70%;
+    x-offset:                    0px;
+    y-offset:                    0px;
+
+    enabled:                     true;
+    margin:                      0px;
+    padding:                     0px;
+    border:                      1px solid;
+    border-radius:               24px;
+    border-color:                @accent1;
+    background-color:            @background;
+    cursor:                      "default";
+}
+
+/*****----- Main Box -----*****/
+mainbox {
+    enabled:                     true;
+    spacing:                     0px;
+    margin:                      0px;
+    padding:                     0px;
+    border:                      0px solid;
+    border-radius:               0px 0px 0px 0px;
+    border-color:                @accent2;
+    background-color:            transparent;
+    children:                    [ "inputbar", "listview" ];
+}
+
+/*****----- Inputbar -----*****/
+inputbar {
+    enabled:                     true;
+    spacing:                     10px;
+    margin:                      0px;
+    padding:                     12px;
+    border:                      0px solid;
+    border-radius:               0px;
+    border-color:                @accent2;
+    background-color:            @background;
+    text-color:                  @accent2;
+    children:                    [ "prompt", "entry" ];
+}
+
+prompt {
+    enabled:                     true;
+    background-color:            inherit;
+    text-color:                  inherit;
+}
+textbox-prompt-colon {
+    enabled:                     true;
+    expand:                      false;
+    str:                         "::";
+    background-color:            inherit;
+    text-color:                  inherit;
+}
+entry {
+    enabled:                     true;
+    background-color:            inherit;
+    text-color:                  inherit;
+    cursor:                      text;
+    placeholder:                 "Search...";
+    placeholder-color:           inherit;
+}
+
+/*****----- Listview -----*****/
+listview {
+    enabled:                     true;
+    columns:                     1;
+    lines:                       6;
+    cycle:                       true;
+    dynamic:                     true;
+    scrollbar:                   false;
+    layout:                      vertical;
+    reverse:                     false;
+    fixed-height:                true;
+    fixed-columns:               true;
+    
+    spacing:                     5px;
+    margin:                      0px;
+    padding:                     0px;
+    border:                      0px solid;
+    border-radius:               0px;
+    border-color:                @accent2;
+    background-color:            transparent;
+    text-color:                  @text;
+    cursor:                      "default";
+}
+scrollbar {
+    handle-width:                5px ;
+    handle-color:                @accent2;
+    border-radius:               0px;
+    background-color:            @accent1-trans;
+}
+
+/*****----- Elements -----*****/
+element {
+    enabled:                     true;
+    spacing:                     10px;
+    margin:                      0px;
+    padding:                     6px;
+    border:                      0px solid;
+    border-radius:               0px;
+    border-color:                @accent2;
+    background-color:            transparent;
+    text-color:                  @foreground;
+    cursor:                      pointer;
+}
+element normal.normal {
+    background-color:            @transparent;
+    text-color:                  @text;
+}
+element selected.normal {
+    background-color:            @transparent;
+    border-color:                @green; 
+    text-color:                  @green;
+}
+element-icon {
+    background-color:            transparent;
+    text-color:                  inherit;
+    size:                        32px;
+    cursor:                      inherit;
+}
+element-text {
+    background-color:            transparent;
+    text-color:                  inherit;
+    highlight:                   bold underline;
+    cursor:                      inherit;
+    vertical-align:              0.5;
+    horizontal-align:            0.0;
+}
+
+/*****----- Message -----*****/
+error-message {
+    padding:                     15px;
+    border:                      0px solid;
+    border-radius:               0px;
+    border-color:                @accent2;
+    background-color:            @background;
+    text-color:                  @text;
+}
+textbox {
+    background-color:            @background;
+    text-color:                  @accent2;
+    vertical-align:              0.5;
+    horizontal-align:            0.0;
+    highlight:                   none;
+}

--- a/.local/bin/hypr-get-keybinds
+++ b/.local/bin/hypr-get-keybinds
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+# Libs
+if ! . "$USER_LIB_DIR/bash/require.sh" logger; then
+  echo "Could not load libraries from '$USER_LIB_DIR'!" >&2
+  exit 1
+fi
+
+# modmask key keycode description dispatcher arg mouse
+declare -r MODMASK=0
+declare -r KEY=1
+declare -r KEYCODE=2
+declare -r DESCRIPTION=3
+declare -r DISPATCHER=4
+declare -r ARG=5
+declare -r MOUSE=6
+# declare -r LOCKED=0
+# declare -r RELEASE=2
+# declare -r REPEAT=3
+# declare -r LONGPRESS=4
+# declare -r NON_CONSUMING=5
+# declare -r AUTO_CONSUMING=6
+# declare -r HAS_DESCRIPTION=7
+# declare -r SUBMAP=9
+# declare -r SUBMAP_UNIVERSAL=10
+declare -r CATCH_ALL=7
+
+parse_modmask() {
+  case "$1" in
+  0) printf '' ;;
+  1) printf 'SHIFT' ;;
+  4) printf 'CTRL' ;;
+  5) printf 'SHIFT CTRL' ;;
+  8) printf 'ALT' ;;
+  9) printf 'SHIFT ALT' ;;
+  12) printf 'CTRL ALT' ;;
+  13) printf 'SHIFT CTRL ALT' ;;
+  64) printf 'SUPER' ;;
+  65) printf 'SUPER SHIFT' ;;
+  68) printf 'SUPER CTRL' ;;
+  69) printf 'SUPER SHIFT CTRL' ;;
+  72) printf 'SUPER ALT' ;;
+  73) printf 'SUPER SHIFT ALT' ;;
+  76) printf 'SUPER CTRL ALT' ;;
+  77) printf 'SUPER SHIFT CTRL ALT' ;;
+  *) printf '%s' "$1" ;;
+  esac
+}
+
+while IFS=$'\x1f' read -r modmask key keycode description dispatcher arg mouse catch_all; do
+  if [[ "$key" == "mouse:272" ]]; then
+    echo "$(parse_modmask $modmask) Left Drag $description"
+  else
+    echo "$(parse_modmask $modmask) $key: $description"
+  fi
+done < <(hyprctl binds -j |
+  jq -r '.[] | 
+    [
+      .modmask, 
+      (.key // ""), 
+      (.keycode // 0), 
+      (.description // ""), 
+      (.dispatcher // ""), 
+      (.arg // ""),
+      (.mouse // 0),
+      (.catch_all // "")
+      | tostring
+    ] 
+    | join("\u001f")')

--- a/.local/bin/hypr-show-keybinds
+++ b/.local/bin/hypr-show-keybinds
@@ -1,69 +1,7 @@
 #!/usr/bin/env bash
 
-# Libs
-if ! . "$USER_LIB_DIR/bash/require.sh" logger; then
-  echo "Could not load libraries from '$USER_LIB_DIR'!" >&2
-  exit 1
-fi
-
-# modmask key keycode description dispatcher arg mouse
-declare -r MODMASK=0
-declare -r KEY=1
-declare -r KEYCODE=2
-declare -r DESCRIPTION=3
-declare -r DISPATCHER=4
-declare -r ARG=5
-declare -r MOUSE=6
-# declare -r LOCKED=0
-# declare -r RELEASE=2
-# declare -r REPEAT=3
-# declare -r LONGPRESS=4
-# declare -r NON_CONSUMING=5
-# declare -r AUTO_CONSUMING=6
-# declare -r HAS_DESCRIPTION=7
-# declare -r SUBMAP=9
-# declare -r SUBMAP_UNIVERSAL=10
-declare -r CATCH_ALL=7
-
-parse_modmask() {
-  case "$1" in
-  0) printf '' ;;
-  1) printf 'SHIFT' ;;
-  4) printf 'CTRL' ;;
-  5) printf 'SHIFT CTRL' ;;
-  8) printf 'ALT' ;;
-  9) printf 'SHIFT ALT' ;;
-  12) printf 'CTRL ALT' ;;
-  13) printf 'SHIFT CTRL ALT' ;;
-  64) printf 'SUPER' ;;
-  65) printf 'SUPER SHIFT' ;;
-  68) printf 'SUPER CTRL' ;;
-  69) printf 'SUPER SHIFT CTRL' ;;
-  72) printf 'SUPER ALT' ;;
-  73) printf 'SUPER SHIFT ALT' ;;
-  76) printf 'SUPER CTRL ALT' ;;
-  77) printf 'SUPER SHIFT CTRL ALT' ;;
-  *) printf '%s' "$1" ;;
-  esac
-}
-
-while IFS=$'\x1f' read -r modmask key keycode description dispatcher arg mouse catch_all; do
-  if [[ "$key" == "mouse:272" ]]; then
-    echo "$(parse_modmask $modmask) Left Drag -> $description"
-  else
-    echo "$(parse_modmask $modmask) ->  $key: $description"
-  fi
-done < <(hyprctl binds -j |
-  jq -r '.[] | 
-    [
-      .modmask, 
-      (.key // ""), 
-      (.keycode // 0), 
-      (.description // ""), 
-      (.dispatcher // ""), 
-      (.arg // ""),
-      (.mouse // 0),
-      (.catch_all // "")
-      | tostring
-    ] 
-    | join("\u001f")')
+~/.local/bin/hypr-get-keybinds | rofi -dmenu \
+  -i \
+  -p "Hyprland Keybinds" \
+  -width 600 \
+  -theme ~/.config/rofi/simple.rasi

--- a/.local/share/dtd/themes/lovely-day/rofi.rasi
+++ b/.local/share/dtd/themes/lovely-day/rofi.rasi
@@ -22,7 +22,7 @@
   /* Named colors */
   red:                #F07178;  /* Soft red — errors, deletions */
   green:              #7FD962;  /* Bright green — strings, additions */
-  green-trans:        #7FD962AA;  /* Bright green — strings, additions */
+  green-trans:        #7FD962AA;/* Bright green — strings, additions */
   blue:               #59C2FF;  /* Sky blue — constants, links */
   orange:             #E6B450;  /* Gold orange — keywords, warnings */
   yellow:             #E6B673;  /* Warm yellow — attributes, tags */

--- a/.local/share/dtd/themes/lovely-day/rofi.rasi
+++ b/.local/share/dtd/themes/lovely-day/rofi.rasi
@@ -5,7 +5,7 @@
   cursor:             #E6B450;  /* Matches accent1 (gold cursor) */
   foreground:         #BFBDB6;  /* Soft white — primary text */
   background:         #0D1017;  /* Deep dark — editor background */
-  background-trans:   #0D1017BB;  /* Deep dark — editor background */
+  background-trans:   #0D1017BB;/* Deep dark — editor background */
   selection-fg:       #BFBDB6;  /* Same as foreground */
   selection-bg:       #273747;  /* Muted blue-grey selection */
 


### PR DESCRIPTION
## Summary

- Split `hypr-show-keybinds` into two scripts: `hypr-get-keybinds` (queries/parses `hyprctl binds`) and `hypr-show-keybinds` (displays results via rofi)
- Add `simple.rasi` rofi theme used by the keybind viewer
- Add bracket key binds for cycling through windows and workspaces
- Swap 3-finger and 4-finger horizontal gesture actions (3=scroll, 4=workspace switch)
- Add `~/.local/bin` to Hyprland PATH env

## Test plan

- [ ] `SUPER + K` opens rofi keybind viewer and is searchable
- [ ] `SUPER + ]` / `SUPER + [` cycle windows/workspaces
- [ ] 3-finger swipe scrolls, 4-finger swipe switches workspaces
- [ ] Scripts in `~/.local/bin` resolve correctly in Hyprland session

🤖 Generated with [Claude Code](https://claude.com/claude-code)