### PR TITLE
feat(hypr): swayosd, media window rules, and minor polish

### DIFF
--- a/.config/hypr/modules/applications/init.lua
+++ b/.config/hypr/modules/applications/init.lua
@@ -1,5 +1,6 @@
 require("modules.applications.1password")
 require("modules.applications.system")
+require("modules.applications.plex")
 
 -- local config_dir = os.getenv("HOME") .. ".config/hypr/modules/applications"
 --

--- a/.config/hypr/modules/applications/plex.lua
+++ b/.config/hypr/modules/applications/plex.lua
@@ -1,0 +1,7 @@
+hl.window_rule({
+  name = "Plex/Plexamp",
+  match = {
+    class = "^(tv.plex.Plex|plexamp)$"
+  },
+  tag = "+media-window"
+})

--- a/.config/hypr/modules/autostart.lua
+++ b/.config/hypr/modules/autostart.lua
@@ -17,6 +17,7 @@ hl.on("hyprland.start", function()
   hl.exec_cmd("awww-daemon")
   -- hl.exec_cmd("systemctl --user start hyprpolkitagent")
   hl.exec_cmd("swaync")
+  hl.exec_cmd("swayosd-server")
   hl.exec_cmd("waybar") -- Execute waybar, hyprpaper, firefox
   hl.exec_cmd("wl-paste --type image --watch cliphist store")
   hl.exec_cmd("wl-paste --type text --watch cliphist store")

--- a/.config/hypr/modules/envs.lua
+++ b/.config/hypr/modules/envs.lua
@@ -19,6 +19,7 @@ hl.config({
 		"CLUTTER_BACKEND,wayland",
 		"GDK_BACKEND,wayland,x11",
 		"MOZ_ENABLE_WAYLAND,1",
-    "PATH,~/.local/bin:$PATH"
+    "PATH,~/.local/bin:$PATH",
+    "USER_LIB_DIR,$HOME/.local/share/dtd/lib"
 	},
 })

--- a/.config/hypr/modules/keybinds.lua
+++ b/.config/hypr/modules/keybinds.lua
@@ -90,34 +90,44 @@ end, { description = "Cycle/move to the previous non-empty workspace."})
 ---- MEDIA/ETC. KEYBINDS ----
 -----------------------------
 -- Laptop multimedia keys for volume and LCD brightness
+-- - Volume
+-- hl.bind("XF86AudioRaiseVolume", hl.dsp.exec_cmd("swayosd-client --output-volume raise"), { locked = true, repeating = true })
+-- hl.bind("XF86AudioLowerVolume", hl.dsp.exec_cmd("swayosd-client --output-volume lower"), { locked = true, repeating = true })
+-- hl.bind("XF86AudioMute",        hl.dsp.exec_cmd("swayosd-client --output-volume mute-toggle"), { locked = true })
+--
+-- -- Brightness
+-- hl.bind("XF86MonBrightnessUp",   hl.dsp.exec_cmd("swayosd-client --brightness raise"), { locked = true, repeating = true })
+-- hl.bind("XF86MonBrightnessDown", hl.dsp.exec_cmd("swayosd-client --brightness lower"), { locked = true, repeating = true })
+
+
 hl.bind(
   "XF86AudioRaiseVolume",
-  hl.dsp.exec_cmd("wpctl set-volume -l 1 @DEFAULT_AUDIO_SINK@ 5%+"),
+  hl.dsp.exec_cmd("swayosd-client --output-volume raise"),
   { description = "󰝝 Raise the Media/Audio Volume", locked = true, repeating = true }
 )
 hl.bind(
   "XF86AudioLowerVolume",
-  hl.dsp.exec_cmd("wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-"),
+  hl.dsp.exec_cmd("swayosd-client --output-volume lower"),
   { description = "󰝞 Lower the Media/Audio Volume", locked = true, repeating = true }
 )
 hl.bind(
   "XF86AudioMute",
-  hl.dsp.exec_cmd("wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle"),
+  hl.dsp.exec_cmd("swayosd-client --output-volume mute-toggle"),
   { description = "󰝟 Mute the Media/Audio Volume", locked = true, repeating = true }
 )
 hl.bind(
   "XF86AudioMicMute",
-  hl.dsp.exec_cmd("wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle"),
+  hl.dsp.exec_cmd("swayosd-client --input-volume mute-toggle"),
   { description = "󰍭 Mute the Input/Microphone Volume", locked = true, repeating = true }
 )
 hl.bind(
   "XF86MonBrightnessUp",
-  hl.dsp.exec_cmd("brightnessctl -e4 -n2 set 5%+"),
+  hl.dsp.exec_cmd("swayosd-client --brightness raise"),
   { description = "󰛨 Increase Screen Brightness", locked = true, repeating = true }
 )
 hl.bind(
   "XF86MonBrightnessDown",
-  hl.dsp.exec_cmd("brightnessctl -e4 -n2 set 5%-"),
+  hl.dsp.exec_cmd("swayosd-client --brightness lower"),
   { description = "󰹏 Decrease Screen Brightness", locked = true, repeating = true }
 )
 

--- a/.config/hypr/modules/windows.lua
+++ b/.config/hypr/modules/windows.lua
@@ -32,6 +32,14 @@ hl.window_rule({
   tag = "+floating-window"
 })
 
+hl.window_rule({
+  name = "media-window",
+  match = { tag = "media-window" },
+  dim_around = true,
+  opacity = "1.0",
+  workspace = "9"
+})
+
 -- hl.window_rule({
 --   name = "multimedia-window",
 --   match = {

--- a/.config/rofi/simple.rasi
+++ b/.config/rofi/simple.rasi
@@ -63,22 +63,24 @@ inputbar {
     border-radius:               0px;
     border-color:                @accent2;
     background-color:            @background;
-    text-color:                  @accent2;
-    children:                    [ "prompt", "entry" ];
+    text-color:                  @foreground;
+    children:                    [ "prompt", "textbox-prompt-colon", "entry" ];
 }
 
 prompt {
     enabled:                     true;
-    background-color:            inherit;
-    text-color:                  inherit;
+    background-color:            @background;
+    text-color:                  @accent2;
 }
+
 textbox-prompt-colon {
     enabled:                     true;
     expand:                      false;
-    str:                         "::";
+    str:                         "";
     background-color:            inherit;
-    text-color:                  inherit;
+    text-color:                  @foreground;
 }
+
 entry {
     enabled:                     true;
     background-color:            inherit;

--- a/.config/swayosd/config.toml
+++ b/.config/swayosd/config.toml
@@ -1,0 +1,4 @@
+[server]
+show_percentage = true
+max_volume = 100
+style = "./style.css"

--- a/.config/swayosd/style.css
+++ b/.config/swayosd/style.css
@@ -1,0 +1,29 @@
+
+@import "../dtd/current/waybar.css";
+
+window {
+  border-radius: 0;
+  opacity: 0.97;
+  border: 2px solid @yellow;
+
+  background-color: @background;
+}
+
+label {
+  font-family: "JetBrainsMono Nerd Font Propo", sans-serif;
+  font-size: 11pt;
+
+  color: @foreground;
+}
+
+image {
+  color: @blue;
+}
+
+progressbar {
+  border-radius: 0;
+}
+
+progress {
+  background-color: @green;
+}

--- a/.config/waybar/config.jsonc
+++ b/.config/waybar/config.jsonc
@@ -36,7 +36,7 @@
         "activated": "",
         "deactivated": ""
       },
-      "timeout": 30.0,
+      "timeout": 60.0,
       "start-activated": false,
       "tooltip": true,
       "tooltip-format-activated": "Idle inhibitor: ON\nScreen will not lock or sleep",

--- a/.config/waybar/style.css
+++ b/.config/waybar/style.css
@@ -75,7 +75,7 @@ window#waybar > box {
 #workspaces button.active {
   color: @green;
   border-radius: 25px;
-  border-bottom: 2px solid alpha(@text1, 0.70);
+  border-bottom: 2px solid @text1;
   border-top: 2px solid @blue;
   transition: all 0.3s ease-in-out;
 }

--- a/.local/bin/hypr-restart-swayosd
+++ b/.local/bin/hypr-restart-swayosd
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+if pgrep -x swayosd-server; then
+  echo "Restarting swayosd-server..."
+  killall -SIGUSR2 swayosd-server
+fi
+
+echo "Starting swayosd-server..."
+swayosd-server &>/dev/null &
+disown

--- a/.local/bin/hypr-restart-theme
+++ b/.local/bin/hypr-restart-theme
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
 hypr-restart-waybar
+hypr-restart-swayosd
+hyprctl reload

--- a/.local/bin/hypr-show-keybinds
+++ b/.local/bin/hypr-show-keybinds
@@ -4,4 +4,5 @@
   -i \
   -p "Hyprland Keybinds" \
   -width 600 \
-  -theme ~/.config/rofi/simple.rasi
+  -theme ~/.config/rofi/simple.rasi \
+  -kb-accept-entry "" -kb-accept-custom "" -kb-accept-alt ""

--- a/install.d/hypr/packages.txt
+++ b/install.d/hypr/packages.txt
@@ -31,6 +31,7 @@ pipewire-pulse
 power-profiles-daemon
 playerctl
 plexamp-bin
+plex-desktop
 plymouth
 plymouth-theme-dark-arch
 popsicle-bin
@@ -41,6 +42,7 @@ satty
 sddm
 slurp
 swaync
+swayosd
 swww
 ttf-firacode-nerd
 ttf-jetbrains-mono-nerd


### PR DESCRIPTION
## Summary

- **swayosd integration**: replace `wpctl`/`brightnessctl` keybinds with `swayosd-client`, autostart `swayosd-server`, add themed config/style, and wire `hypr-restart-swayosd` into `hypr-restart-theme`
- **Plex/Plexamp media window**: consolidate into a single `plex.lua` rule matching both classes, tagged `media-window` with dim, full opacity, and workspace 9
- **Misc**: add `USER_LIB_DIR` env var, refine rofi keybind viewer layout, bump waybar idle inhibitor timeout and active workspace border, add `plex-desktop` + `swayosd` to package list

## Test plan

- [ ] Volume up/down/mute keys show swayosd overlay
- [ ] Mic mute key shows swayosd overlay
- [ ] Brightness up/down keys show swayosd overlay
- [ ] `hypr-restart-theme` restarts swayosd cleanly
- [ ] Plex and Plexamp open on workspace 9 with dim effect
- [ ] Rofi keybind viewer renders correctly