### PR TITLE
feat(dev): nvm/Node setup and gesture tweak

### DIFF
--- a/.config/hypr/modules/layouts.lua
+++ b/.config/hypr/modules/layouts.lua
@@ -25,6 +25,6 @@ hl.config({
 })
 
 hl.gesture({ fingers = 3, direction = "horizontal", scale = 1.5, action = "scroll_move" })
-hl.gesture({ fingers = 4, direction = "horizontal", scale = 1.5, action = "workspace" })
+hl.gesture({ fingers = 3, mods = "SHIFT", direction = "horizontal", scale = 1.5, action = "workspace" })
 hl.gesture({ fingers = 3, direction = "down", scale = 1.5, mods = "ALT", action = "close" })
 hl.gesture({ fingers = 4, direction = "pinchout", scale = 1.5, action = "fullscreen" })

--- a/.local/share/dtd/shell/shared.envs.sh
+++ b/.local/share/dtd/shell/shared.envs.sh
@@ -59,6 +59,10 @@ declare -rx USER_ENVS_LOADED=1 &> /dev/null
 export LIBGUESTFS_BACKEND=direct
 export LIBVIRT_DEFAULT_URI="qemu:///system"
 
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+
 # if [[ -n "${USER_ENVS_LOADED}" ]]; then
 #     # echo "USER_ENVS already loaded by '$0'." 
 #     return 0

--- a/.zshrc
+++ b/.zshrc
@@ -7,3 +7,8 @@ fi
 fpath+=~/.zfunc; autoload -Uz compinit; compinit
 
 zstyle ':completion:*' menu select
+
+
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion

--- a/install.d/dev/node.sh
+++ b/install.d/dev/node.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+echo ">>> Fetching latest nvm version..."
+NVM_VERSION=$(curl -fsSL https://api.github.com/repos/nvm-sh/nvm/releases/latest | grep '"tag_name"' | cut -d'"' -f4)
+
+echo ">>> Installing nvm ${NVM_VERSION}..."
+curl -fsSL "https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh" | bash
+
+# 2. Load nvm into current shell session
+export NVM_DIR="$HOME/.nvm"
+
+# shellcheck source=/dev/null
+[ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh"
+
+nvm install "--lts"


### PR DESCRIPTION
## Summary

- **nvm/Node**: add `install.d/dev/node.sh` to fetch latest nvm and install Node LTS; load nvm in `shared.envs.sh` and `.zshrc`
- **gesture**: change workspace swipe from 4-finger horizontal to 3-finger+SHIFT horizontal

## Test plan

- [ ] Run `install.d/dev/node.sh` on a fresh machine — nvm installs and `node --version` works
- [ ] Open a new shell — `nvm` command is available
- [ ] 3-finger+SHIFT horizontal swipe switches workspaces