### PR TITLE
feat(btop): add config, theme symlink, and lovely-day palette update

### DIFF
--- a/.config/btop/btop.conf
+++ b/.config/btop/btop.conf
@@ -1,0 +1,286 @@
+#? Config file for btop v.1.4.7
+
+#* Name of a btop++/bpytop/bashtop formatted ".theme" file, "Default" and "TTY" for builtin themes.
+#* Themes should be placed in "../share/btop/themes" relative to binary or "$HOME/.config/btop/themes"
+color_theme = "current"
+
+#* If the theme set background should be shown, set to False if you want terminal background transparency.
+theme_background = true
+
+#* Sets if 24-bit truecolor should be used, will convert 24-bit colors to 256 color (6x6x6 color cube) if false.
+truecolor = true
+
+#* Set to true to force tty mode regardless if a real tty has been detected or not.
+#* Will force 16-color mode and TTY theme, set all graph symbols to "tty" and swap out other non tty friendly symbols.
+force_tty = false
+
+#* Option to disable presets. Either the default preset, custom presets, or all presets.
+#* "Off" All presets are enabled.
+#* "Default" preset is disabled.#* "Custom" presets are disabled.#* "All" presets are disabled.
+disable_presets = "Off"
+
+#* Define presets for the layout of the boxes. Preset 0 is always all boxes shown with default settings. Max 9 presets.
+#* Format: "box_name:P:G,box_name:P:G" P=(0 or 1) for alternate positions, G=graph symbol to use for box.
+#* Use whitespace " " as separator between different presets.
+#* Example: "cpu:0:default,mem:0:tty,proc:1:default cpu:0:braille,proc:0:tty"
+presets = "cpu:1:default,proc:0:default cpu:0:default,mem:0:default,net:0:default cpu:0:block,net:0:tty"
+
+#* Set to True to enable "h,j,k,l,g,G" keys for directional control in lists.
+#* Conflicting keys for h:"help" and k:"kill" is accessible while holding shift.
+vim_keys = true
+
+#* Disable all mouse events.
+disable_mouse = false
+
+#* Rounded corners on boxes, is ignored if TTY mode is ON.
+rounded_corners = true
+
+#* Use terminal synchronized output sequences to reduce flickering on supported terminals.
+terminal_sync = true
+
+#* Default symbols to use for graph creation, "braille", "block" or "tty".
+#* "braille" offers the highest resolution but might not be included in all fonts.
+#* "block" has half the resolution of braille but uses more common characters.
+#* "tty" uses only 3 different symbols but will work with most fonts and should work in a real TTY.
+#* Note that "tty" only has half the horizontal resolution of the other two, so will show a shorter historical view.
+graph_symbol = "braille"
+
+# Graph symbol to use for graphs in cpu box, "default", "braille", "block" or "tty".
+graph_symbol_cpu = "default"
+
+# Graph symbol to use for graphs in gpu box, "default", "braille", "block" or "tty".
+graph_symbol_gpu = "default"
+
+# Graph symbol to use for graphs in cpu box, "default", "braille", "block" or "tty".
+graph_symbol_mem = "default"
+
+# Graph symbol to use for graphs in cpu box, "default", "braille", "block" or "tty".
+graph_symbol_net = "default"
+
+# Graph symbol to use for graphs in cpu box, "default", "braille", "block" or "tty".
+graph_symbol_proc = "default"
+
+#* Manually set which boxes to show. Available values are "cpu mem net proc" and "gpu0" through "gpu5", separate values with whitespace.
+shown_boxes = "proc cpu"
+
+#* Update time in milliseconds, recommended 2000 ms or above for better sample times for graphs.
+update_ms = 2000
+
+#* Processes sorting, "pid" "program" "arguments" "threads" "user" "memory" "cpu lazy" "cpu direct",
+#* "cpu lazy" sorts top process over time (easier to follow), "cpu direct" updates top process directly.
+proc_sorting = "cpu lazy"
+
+#* Reverse sorting order, True or False.
+proc_reversed = false
+
+#* Show processes as a tree.
+proc_tree = false
+
+#* Use the cpu graph colors in the process list.
+proc_colors = true
+
+#* Use a darkening gradient in the process list.
+proc_gradient = true
+
+#* If process cpu usage should be of the core it's running on or usage of the total available cpu power.
+proc_per_core = false
+
+#* Show process memory as bytes instead of percent.
+proc_mem_bytes = true
+
+#* Show cpu graph for each process.
+proc_cpu_graphs = true
+
+#* Use /proc/[pid]/smaps for memory information in the process info box (very slow but more accurate)
+proc_info_smaps = false
+
+#* Show proc box on left side of screen instead of right.
+proc_left = false
+
+#* (Linux) Filter processes tied to the Linux kernel(similar behavior to htop).
+proc_filter_kernel = false
+
+#* Should the process list follow the selected process when detailed view is open.
+proc_follow_detailed = true
+
+#* In tree-view, always accumulate child process resources in the parent process.
+proc_aggregate = false
+
+#* Should cpu and memory usage display be preserved for dead processes when paused.
+keep_dead_proc_usage = false
+
+#* Sets the CPU stat shown in upper half of the CPU graph, "total" is always available.
+#* Select from a list of detected attributes from the options menu.
+cpu_graph_upper = "Auto"
+
+#* Sets the CPU stat shown in lower half of the CPU graph, "total" is always available.
+#* Select from a list of detected attributes from the options menu.
+cpu_graph_lower = "Auto"
+
+#* If gpu info should be shown in the cpu box. Available values = "Auto", "On" and "Off".
+show_gpu_info = "Auto"
+
+#* Toggles if the lower CPU graph should be inverted.
+cpu_invert_lower = true
+
+#* Set to True to completely disable the lower CPU graph.
+cpu_single_graph = false
+
+#* Show cpu box at bottom of screen instead of top.
+cpu_bottom = false
+
+#* Shows the system uptime in the CPU box.
+show_uptime = true
+
+#* Shows the CPU package current power consumption in watts. Requires running `make setcap` or `make setuid` or running with sudo.
+show_cpu_watts = true
+
+#* Show cpu temperature.
+check_temp = true
+
+#* Which sensor to use for cpu temperature, use options menu to select from list of available sensors.
+cpu_sensor = "Auto"
+
+#* Show temperatures for cpu cores also if check_temp is True and sensors has been found.
+show_coretemp = true
+
+#* Set a custom mapping between core and coretemp, can be needed on certain cpus to get correct temperature for correct core.
+#* Use lm-sensors or similar to see which cores are reporting temperatures on your machine.
+#* Format "x:y" x=core with wrong temp, y=core with correct temp, use space as separator between multiple entries.
+#* Example: "4:0 5:1 6:3"
+cpu_core_map = ""
+
+#* Which temperature scale to use, available values: "celsius", "fahrenheit", "kelvin" and "rankine".
+temp_scale = "celsius"
+
+#* Use base 10 for bits/bytes sizes, KB = 1000 instead of KiB = 1024.
+base_10_sizes = false
+
+#* Show CPU frequency.
+show_cpu_freq = true
+
+#* How to calculate CPU frequency, available values: "first", "range", "lowest", "highest" and "average".
+freq_mode = "first"
+
+#* Draw a clock at top of screen, formatting according to strftime, empty string to disable.
+#* Special formatting: /host = hostname | /user = username | /uptime = system uptime
+clock_format = "%X"
+
+#* Update main ui in background when menus are showing, set this to false if the menus is flickering too much for comfort.
+background_update = true
+
+#* Custom cpu model name, empty string to disable.
+custom_cpu_name = ""
+
+#* Optional filter for shown disks, should be full path of a mountpoint, separate multiple values with whitespace " ".
+#* Only disks matching the filter will be shown. Prepend exclude= to only show disks not matching the filter. Examples: disk_filter="/boot /home/user", disks_filter="exclude=/boot /home/user"
+disks_filter = ""
+
+#* Show graphs instead of meters for memory values.
+mem_graphs = true
+
+#* Show mem box below net box instead of above.
+mem_below_net = false
+
+#* Count ZFS ARC in cached and available memory.
+zfs_arc_cached = true
+
+#* If swap memory should be shown in memory box.
+show_swap = true
+
+#* Show swap as a disk, ignores show_swap value above, inserts itself after first disk.
+swap_disk = true
+
+#* If mem box should be split to also show disks info.
+show_disks = true
+
+#* Filter out non physical disks. Set this to False to include network disks, RAM disks and similar.
+only_physical = true
+
+#* Read disks list from /etc/fstab. This also disables only_physical.
+use_fstab = true
+
+#* Setting this to True will hide all datasets, and only show ZFS pools. (IO stats will be calculated per-pool)
+zfs_hide_datasets = false
+
+#* Set to true to show available disk space for privileged users.
+disk_free_priv = false
+
+#* Toggles if io activity % (disk busy time) should be shown in regular disk usage view.
+show_io_stat = true
+
+#* Toggles io mode for disks, showing big graphs for disk read/write speeds.
+io_mode = false
+
+#* Set to True to show combined read/write io graphs in io mode.
+io_graph_combined = false
+
+#* Set the top speed for the io graphs in MiB/s (100 by default), use format "mountpoint:speed" separate disks with whitespace " ".
+#* Example: "/mnt/media:100 /:20 /boot:1".
+io_graph_speeds = ""
+
+#* Swap the positions of the upload and download speed graphs. When true, upload will be on top.
+swap_upload_download = false
+
+#* Set fixed values for network graphs in Mebibits. Is only used if net_auto is also set to False.
+net_download = 100
+
+net_upload = 100
+
+#* Use network graphs auto rescaling mode, ignores any values set above and rescales down to 10 Kibibytes at the lowest.
+net_auto = true
+
+#* Sync the auto scaling for download and upload to whichever currently has the highest scale.
+net_sync = true
+
+#* Starts with the Network Interface specified here.
+net_iface = ""
+
+#* "True" shows bitrates in base 10 (Kbps, Mbps). "False" shows bitrates in binary sizes (Kibps, Mibps, etc.). "Auto" uses base_10_sizes.
+base_10_bitrate = "Auto"
+
+#* Show battery stats in top right if battery is present.
+show_battery = true
+
+#* Which battery to use if multiple are present. "Auto" for auto detection.
+selected_battery = "Auto"
+
+#* Show power stats of battery next to charge indicator.
+show_battery_watts = true
+
+#* Set loglevel for "~/.local/state/btop.log" levels are: "ERROR" "WARNING" "INFO" "DEBUG".
+#* The level set includes all lower levels, i.e. "DEBUG" will show all logging info.
+log_level = "WARNING"
+
+#* Automatically save current settings to config file on exit.
+save_config_on_exit = true
+
+#* Measure PCIe throughput on NVIDIA cards, may impact performance on certain cards.
+nvml_measure_pcie_speeds = true
+
+#* Measure PCIe throughput on AMD cards, may impact performance on certain cards.
+rsmi_measure_pcie_speeds = true
+
+#* Horizontally mirror the GPU graph.
+gpu_mirror_graph = true
+
+#* Set which GPU vendors to show. Available values are "nvidia amd intel apple"
+shown_gpus = "nvidia amd intel"
+
+#* Custom gpu0 model name, empty string to disable.
+custom_gpu_name0 = ""
+
+#* Custom gpu1 model name, empty string to disable.
+custom_gpu_name1 = ""
+
+#* Custom gpu2 model name, empty string to disable.
+custom_gpu_name2 = ""
+
+#* Custom gpu3 model name, empty string to disable.
+custom_gpu_name3 = ""
+
+#* Custom gpu4 model name, empty string to disable.
+custom_gpu_name4 = ""
+
+#* Custom gpu5 model name, empty string to disable.
+custom_gpu_name5 = ""

--- a/.config/btop/themes/current.theme
+++ b/.config/btop/themes/current.theme
@@ -1,0 +1,1 @@
+/home/dtd/.config/dtd/current/btop.theme

--- a/.config/waybar/config.jsonc
+++ b/.config/waybar/config.jsonc
@@ -127,7 +127,8 @@
     "on-click": "activate",
     "sort-by-number": true,
     "format-icons": {
-      "active": ""
+      "9": "",
+      "10": "󰒃"
     },
     "persistent-workspaces": {
       "*": 5 // 5 workspaces by default on every monitor

--- a/.local/share/dtd/themes/lovely-day/btop.theme
+++ b/.local/share/dtd/themes/lovely-day/btop.theme
@@ -8,7 +8,7 @@ theme[main_fg]="#9F9F84"
 theme[title]="#9F9F84"
 
 # Highlight color for keyboard shortcuts
-theme[hi_fg]="#2895A3"
+theme[hi_fg]="#59C2FF"
 
 # Background color of selected item in processes box. #9F9F84 maps to
 # the foreground role in aether (terminal selection wants inverted contrast),
@@ -19,7 +19,7 @@ theme[selected_bg]="#1a2023"
 
 # Foreground color of selected item in processes box. Use #9F9F84 so
 # the row text stays readable on the lighter_bg highlight; the previous
-# #2895A3 produced low-contrast blue-on-white in dark themes.
+# #59C2FF produced low-contrast blue-on-white in dark themes.
 theme[selected_fg]="#9F9F84"
 
 # Color of inactive/disabled text
@@ -35,59 +35,59 @@ theme[graph_text]="#9F9F84"
 theme[meter_bg]="#1a2023"
 
 # Misc colors for processes box including mini cpu graphs, details memory graph and details status text.
-# Use #368B8D for a distinct accent instead of #adad96 which capped to white.
-theme[proc_misc]="#368B8D"
+# Use #39BAE6 for a distinct accent instead of #adad96 which capped to white.
+theme[proc_misc]="#39BAE6"
 
 # CPU, Memory, Network, Proc box outline colors
-theme[cpu_box]="#966f4c"
-theme[mem_box]="#5d7f63"
-theme[net_box]="#a96d2f"
-theme[proc_box]="#2895A3"
+theme[cpu_box]="#BFBDB6"
+theme[mem_box]="#7FD962"
+theme[net_box]="#D2A6FF"
+theme[proc_box]="#59C2FF"
 
 # Box divider line and small boxes line color
 theme[div_line]="#636a6d"
 
 # Temperature graph color (Green -> Yellow -> Red)
-theme[temp_start]="#5d7f63"
-theme[temp_mid]="#87804e"
-theme[temp_end]="#a96d2f"
+theme[temp_start]="#7FD962"
+theme[temp_mid]="#BFBDB6"
+theme[temp_end]="#D2A6FF" # #D2A6FF
 
 # CPU graph colors (Teal -> Blue -> Purple)
-theme[cpu_start]="#368B8D"
-theme[cpu_mid]="#2895A3"
-theme[cpu_end]="#966f4c"
+theme[cpu_start]="#39BAE6"
+theme[cpu_mid]="#59C2FF"
+theme[cpu_end]="#BFBDB6"
 
 # Mem/Disk free meter
-theme[free_start]="#966f4c"
-theme[free_mid]="#2895A3"
-theme[free_end]="#368B8D"
+theme[free_start]="#BFBDB6"
+theme[free_mid]="#59C2FF"
+theme[free_end]="#39BAE6"
 
 # Mem/Disk cached meter
-theme[cached_start]="#2895A3"
-theme[cached_mid]="#368B8D"
-theme[cached_end]="#966f4c"
+theme[cached_start]="#59C2FF"
+theme[cached_mid]="#39BAE6"
+theme[cached_end]="#BFBDB6"
 
 # Mem/Disk available meter
-theme[available_start]="#87804e"
-theme[available_mid]="#a96d2f"
-theme[available_end]="#a96d2f"
+theme[available_start]="#BFBDB6"
+theme[available_mid]="#D2A6FF"
+theme[available_end]="#D2A6FF"
 
 # Mem/Disk used meter (Green -> Teal -> Blue)
-theme[used_start]="#5d7f63"
-theme[used_mid]="#368B8D"
-theme[used_end]="#2895A3"
+theme[used_start]="#7FD962" # #7FD962
+theme[used_mid]="#39BAE6" # #39BAE6
+theme[used_end]="#59C2FF" # #59C2FF
 
 # Download graph colors
-theme[download_start]="#87804e"
-theme[download_mid]="#a96d2f"
-theme[download_end]="#a96d2f"
+theme[download_start]="#BFBDB6"
+theme[download_mid]="#D2A6FF"
+theme[download_end]="#D2A6FF"
 
 # Upload graph colors (Green -> Teal -> Blue)
-theme[upload_start]="#5d7f63"
-theme[upload_mid]="#368B8D"
-theme[upload_end]="#2895A3"
+theme[upload_start]="#7FD962"
+theme[upload_mid]="#39BAE6"
+theme[upload_end]="#59C2FF"
 
 # Process box color gradient for threads, mem and cpu usage
-theme[process_start]="#368B8D"
-theme[process_mid]="#2895A3"
-theme[process_end]="#966f4c"
+theme[process_start]="#39BAE6"
+theme[process_mid]="#59C2FF"
+theme[process_end]="#BFBDB6"


### PR DESCRIPTION
## Summary

- **btop config**: add `btop.conf` with `color_theme = "current"`, vim keys, braille graphs, and standard layout
- **theme symlink**: add `themes/current.theme` pointing to `~/.config/dtd/current/btop.theme` so the themed config is picked up automatically
- **lovely-day palette**: update `btop.theme` colors from warm ochre/teal to Aether blues and greens to match the rest of the theme

## Test plan

- [ ] Launch btop — theme loads without falling back to default
- [ ] Volume/brightness colors match Aether palette
- [ ] Box outlines use correct accent colors