### PR TITLE
fix(env): add zprofile source and comment out duplicate hypr env vars

### DIFF
--- a/.config/hypr/modules/envs.lua
+++ b/.config/hypr/modules/envs.lua
@@ -25,3 +25,6 @@ hl.config({
 		"USER_LIB_DIR," .. home .. "/.local/share/dtd/lib",
 	},
 })
+
+-- hl.env("PATH", home .. "/.local/bin:$PATH")
+-- hl.env("USER_LIB_DIR", home .. "/.local/shared/dtd/lib")

--- a/.zprofile
+++ b/.zprofile
@@ -1,4 +1,6 @@
 
+source ~/.local/share/dtd/shell/zsh.rc.sh
+
 if [ -z "$DISPLAY" ] && [ "$(tty)" = "/dev/tty1" ]; then
   if $(gum confirm "Start Hyprland?"); then
     gum log --level info "Starting Hyprland..."


### PR DESCRIPTION
## Summary
- Sources `~/.local/share/dtd/shell/zsh.rc.sh` in `.zprofile` so shared shell config is loaded on login
- Comments out duplicate `PATH` and `USER_LIB_DIR` env vars in `envs.lua` that are already set via `hl.config`

## Test plan
- [ ] Login shell sources the shared rc file without errors
- [ ] Hyprland env vars are set correctly (no duplicates)