### PR TITLE
feat(hypr): add web app install and launch scripts

### DIFF
--- a/.local/bin/hypr-install-webapp
+++ b/.local/bin/hypr-install-webapp
@@ -1,0 +1,90 @@
+
+#!/usr/bin/env bash
+
+set -e
+
+ICON_DIR="$HOME/.local/share/applications/icons"
+
+if (( $# < 3 )); then
+  echo -e "\e[32mLet's create a new web app you can start with the app launcher.\n\e[0m"
+  APP_NAME=$(gum input --prompt "Name> " --placeholder "My favorite web app")
+  APP_URL=$(gum input --prompt "URL> " --placeholder "https://example.com")
+  if [[ ! $APP_URL =~ ^[a-zA-Z][a-zA-Z0-9+.-]*: ]]; then
+    APP_URL="https://$APP_URL"
+  fi
+
+  # Try to fetch favicon automatically first.
+  FAVICON_URL="https://www.google.com/s2/favicons?domain=${APP_URL}&sz=128"
+  mkdir -p "$ICON_DIR"
+  if curl -fsSL -o "$ICON_DIR/$APP_NAME.png" "$FAVICON_URL" && [[ -s $ICON_DIR/$APP_NAME.png ]]; then
+    ICON_REF="$APP_NAME.png"
+  else
+    ICON_REF=$(gum input --prompt "Icon URL> " --placeholder "Could not fetch favicon automatically. Enter PNG icon URL (see https://dashboardicons.com)")
+  fi
+
+  CUSTOM_EXEC=""
+  MIME_TYPES=""
+  INTERACTIVE_MODE=true
+else
+  APP_NAME="$1"
+  APP_URL="$2"
+  if [[ ! $APP_URL =~ ^[a-zA-Z][a-zA-Z0-9+.-]*: ]]; then
+    APP_URL="https://$APP_URL"
+  fi
+  ICON_REF="$3"
+  CUSTOM_EXEC="$4" # Optional custom exec command
+  MIME_TYPES="$5"  # Optional mime types
+  INTERACTIVE_MODE=false
+fi
+
+# Ensure valid execution
+if [[ -z $APP_NAME || -z $APP_URL ]]; then
+  echo "You must set app name and app URL!"
+  exit 1
+fi
+
+# Resolve icon from URL or from a local icon name.
+mkdir -p "$ICON_DIR"
+
+if [[ -z $ICON_REF ]]; then
+  ICON_REF="https://www.google.com/s2/favicons?domain=${APP_URL}&sz=128"
+fi
+
+if [[ $ICON_REF =~ ^https?:// ]]; then
+  ICON_PATH="$ICON_DIR/$APP_NAME.png"
+  if ! curl -fsSL -o "$ICON_PATH" "$ICON_REF" || [[ ! -s $ICON_PATH ]]; then
+    echo "Error: Failed to download icon."
+    exit 1
+  fi
+else
+  ICON_PATH="$ICON_DIR/$ICON_REF"
+fi
+
+# Use custom exec if provided, otherwise default behavior
+EXEC_COMMAND="${CUSTOM_EXEC:-hypr-launch-webapp $APP_URL}"
+
+# Create application .desktop file
+DESKTOP_FILE="$HOME/.local/share/applications/$APP_NAME.desktop"
+
+cat >"$DESKTOP_FILE" <<EOF
+[Desktop Entry]
+Version=1.0
+Name=$APP_NAME
+Comment=$APP_NAME
+Exec=$EXEC_COMMAND
+Terminal=false
+Type=Application
+Icon=$ICON_PATH
+StartupNotify=true
+EOF
+
+# Add mime types if provided
+if [[ -n $MIME_TYPES ]]; then
+  echo "MimeType=$MIME_TYPES" >>"$DESKTOP_FILE"
+fi
+
+chmod +x "$DESKTOP_FILE"
+
+if [[ $INTERACTIVE_MODE == "true" ]]; then
+  echo -e "You can now find $APP_NAME using the app launcher (SUPER + SPACE)\n"
+fi

--- a/.local/bin/hypr-launch-webapp
+++ b/.local/bin/hypr-launch-webapp
@@ -1,0 +1,17 @@
+
+#!/usr/bin/env bash
+
+# omarchy:summary=Launch a URL as a web app in the default supported browser
+# omarchy:args=<url>
+
+browser=$(xdg-settings get default-web-browser)
+
+case $browser in
+google-chrome* | brave* | microsoft-edge* | opera* | vivaldi* | helium*) ;;
+*) browser="chromium.desktop" ;;
+esac
+
+desktop_file=$(ls ~/.local/share/applications/$browser /usr/share/applications/$browser 2>/dev/null | head -1)
+exec_bin=$(grep -m1 '^Exec=' "$desktop_file" | cut -d= -f2 | cut -d' ' -f1)
+
+exec "$exec_bin" --app="$1" "${@:2}"

--- a/install.d/hypr/all.sh
+++ b/install.d/hypr/all.sh
@@ -30,6 +30,8 @@ MODULES=(
   packages.sh
   sddm.sh
   autologin.sh
+  webapps.sh
+  keyring.sh
   desktop.sh
   clean.sh
 )

--- a/install.d/hypr/webapps.sh
+++ b/install.d/hypr/webapps.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+hypr-install-webapp "Gitea" "https://gitea.snork.co" "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/gitea.svg"
+hypr-install-webapp "Github" "https://github.com/TylerDurham" "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/github-light.svg"
+hypr-install-webapp "Claude.ai" "https://claude.ai/new" "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/claude-ai.svg"


### PR DESCRIPTION
## Summary
- Adds `hypr-launch-webapp`: launches a URL as a PWA-style web app in the default Chromium-based browser using `--app=<url>`
- Adds `hypr-install-webapp`: creates a `.desktop` entry for a web app, fetching the favicon automatically; supports both interactive (gum prompts) and non-interactive modes
- Adds `install.d/hypr/webapps.sh`: seeds Gitea, GitHub, and Claude.ai as installed web apps
- Also includes env fixes: sources shared zsh rc in `.zprofile` and cleans up duplicate env vars in `envs.lua`

## Test plan
- [ ] `hypr-launch-webapp https://example.com` opens in Brave with `--app` flag
- [ ] `hypr-install-webapp` in interactive mode prompts for name/URL and creates a `.desktop` file
- [ ] `install.d/hypr/webapps.sh` installs Gitea, GitHub, and Claude.ai entries without errors
- [ ] Web apps appear in the app launcher (SUPER + SPACE)